### PR TITLE
修复：无法添加记录问题

### DIFF
--- a/client/src/api/expenses.js
+++ b/client/src/api/expenses.js
@@ -45,15 +45,17 @@ export const ExpenseAPI = {
   async addExpense(data) {
     try {
       return await axios.post(`${API_BASE}/expenses`, data, {
-  headers: {
-    'Content-Type': 'application/json',
-    'X-Requested-With': 'XMLHttpRequest'
-  },
-  transformRequest: [(data) => JSON.stringify({
-    ...data,
-    amount: parseFloat(data.amount)
-  })]
-});
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest'
+        },
+        transformRequest: [(data) => JSON.stringify({
+          ...data,
+          amount: parseFloat(data.amount),
+          // 修复：确保itemName字段存在，如果没有则使用remark字段的值
+          itemName: data.itemName || data.remark || ''
+        })]
+      });
     } catch (error) {
       console.error('添加消费数据失败:', error);
       throw error; // 添加操作失败需要向上抛出错误


### PR DESCRIPTION
## 问题描述
添加消费记录时出现HTTP 400错误，导致无法添加新记录。

## 原因分析
后端API要求`itemName`字段为必填，但前端表单和API调用中未传递该字段。

## 修复方案
在前端API调用中添加`itemName`字段处理逻辑，确保即使用户没有输入该字段，也会使用`remark`字段的值作为`itemName`传递给后端。

## 修复内容
- 修改`client/src/api/expenses.js`文件，在`addExpense`方法中添加`itemName`字段处理逻辑

## 测试结果
修复后可以正常添加消费记录，不再出现HTTP 400错误。