### PR TITLE
修复: 使用remark替代itemName字段，解决数据添加失败问题

### DIFF
--- a/client/src/api/expenses.js
+++ b/client/src/api/expenses.js
@@ -52,8 +52,8 @@ export const ExpenseAPI = {
         transformRequest: [(data) => JSON.stringify({
           ...data,
           amount: parseFloat(data.amount),
-          // 修复：确保itemName字段存在，如果没有则使用remark字段的值
-          itemName: data.itemName || data.remark || ''
+          // 使用remark字段，不再需要itemName
+          remark: data.remark || ''
         })]
       });
     } catch (error) {

--- a/server/src/controllers/expenses.js
+++ b/server/src/controllers/expenses.js
@@ -63,7 +63,7 @@ exports.addExpense = async (req, res) => {
     // 新增数据预处理
     const processedData = {
       type: String(req.body.type || '').trim(),
-      itemName: String(req.body.itemName || '').trim(),
+      itemName: String(req.body.remark || '').trim(), // 使用remark替代itemName
       amount: parseFloat(req.body.amount) || 0,
       time: dayjs(req.body.time).isValid() 
         ? dayjs(req.body.time).format('YYYY-MM-DD')
@@ -88,7 +88,7 @@ exports.addExpense = async (req, res) => {
     const data = await exportService.getFullData();
     const csvContent = Papa.unparse(data.map(item => ({
       type: item.type || '未分类',
-      remark: item.remark || '',
+      remark: item.remark || item.itemName || '',
       amount: Number(item.amount || 0).toFixed(2),
       time: item.time ? dayjs(item.time).format('YYYY-MM-DD') : dayjs().format('YYYY-MM-DD')
     })), {

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -14,8 +14,8 @@ class ExpenseBuilder {
     }
 
     setItemName(itemName) {
-      if (!itemName) throw new Error('消费项目名称不能为空');
-      this.expense.itemName = itemName;
+      // 使用remark替代itemName，不再强制验证
+      this.expense.itemName = itemName || '';
       return this;
     }
 
@@ -33,7 +33,6 @@ class ExpenseBuilder {
 
     build() {
       if (!this.expense.type) throw new Error('消费类型不能为空');
-      if (!this.expense.itemName) throw new Error('消费项目名称不能为空');
       if (typeof this.expense.amount !== 'number' || this.expense.amount <= 0) throw new Error('消费金额必须为正数');
       if (!this.expense.time || isNaN(Date.parse(this.expense.time))) throw new Error('时间格式无效');
       return this.expense;

--- a/server/src/utils/export.js
+++ b/server/src/utils/export.js
@@ -16,8 +16,8 @@ class ExportService {
   async generateCSV() {
     const data = await this.getFullData(); // 等待数据获取完成
     const csvContent = [
-      '消费类型,项目名称,金额,时间',
-      ...data.map(item => `${item.type},${item.itemName},${item.amount},${item.time}`)
+      '消费类型,备注,金额,时间',
+      ...data.map(item => `${item.type},${item.remark || item.itemName || ''},${item.amount},${item.time}`)
     ].join('\n');
     
     const exportDir = path.join(__dirname, '../../exports/');


### PR DESCRIPTION
修复了issue #7中提到的无法添加数据的问题。

问题原因：
- 前端表单中只有remark字段，没有itemName字段
- 后端却要求itemName字段必填，导致400错误

修复方法：
1. 修改后端db.js，移除对itemName的强制验证
2. 修改controllers/expenses.js，使用remark替代itemName
3. 修改前端API，调整数据传输逻辑
4. 修改export.js，确保CSV导出兼容性

这些修改确保了数据添加功能正常工作，同时保持了与现有数据的兼容性。